### PR TITLE
fix(completion): prevent colon trigger from firing outside verbatim context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-analysis"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ignore",
  "lex-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "lex-analysis",
  "lex-babel",

--- a/lex-analysis/Cargo.toml
+++ b/lex-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-analysis"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Semantic analysis for the lex format"

--- a/lex-analysis/src/completion.rs
+++ b/lex-analysis/src/completion.rs
@@ -115,6 +115,17 @@ pub fn completion_items(
         if trigger == "|" {
             return table_row_completions(document, position);
         }
+        if trigger == ":" {
+            // Only offer verbatim labels when actually at a verbatim block start or
+            // inside an existing verbatim label. Don't pollute completion for
+            // arbitrary colons (e.g. definition subjects like "Ideas:").
+            if is_at_potential_verbatim_start(document, position, current_line)
+                || is_inside_verbatim_label(document, position)
+            {
+                return verbatim_label_completions(document);
+            }
+            return Vec::new();
+        }
     }
 
     match detect_context(document, position, current_line) {
@@ -782,6 +793,19 @@ Code sample:
 
         assert!(completions.iter().any(|c| c.label == "doc.code"));
         assert!(completions.iter().any(|c| c.label == "rust"));
+    }
+
+    #[test]
+    fn colon_trigger_in_definition_subject_returns_nothing() {
+        let text = "Ideas:";
+        let document = parsing::parse_document(text).expect("parses");
+        let pos = Position::new(0, 6); // after "Ideas:"
+        let completions = completion_items(&document, pos, Some("Ideas:"), None, Some(":"));
+        assert!(
+            completions.is_empty(),
+            "colon in definition subject should not trigger completions, got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/lex-lsp/Cargo.toml
+++ b/lex-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex-lsp"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["lex contributors"]
 description = "Language Server Protocol implementation for the lex format"
@@ -18,7 +18,7 @@ path = "src/bin/lex-lsp.rs"
 
 [dependencies]
 lex-core = { workspace = true }
-lex-analysis = { version = "0.3.1", path = "../lex-analysis" }
+lex-analysis = { version = "0.3.2", path = "../lex-analysis" }
 lex-babel = { workspace = true }
 tower-lsp = "0.20"
 lsp-types = "0.94"


### PR DESCRIPTION
## Summary
- The `:` trigger character was firing on any colon (e.g. definition subjects like `Ideas:`), falling through to General context and returning spurious reference/path completions
- Now `:` only returns verbatim label completions when at a verbatim block start (`::`) or inside an existing verbatim label — returns empty otherwise
- Bumps lex-analysis 0.3.1 → 0.3.2, lex-lsp 0.3.2 → 0.3.3

## Test plan
- [x] New test: `colon_trigger_in_definition_subject_returns_nothing`
- [x] Existing test: `trigger_colon_at_block_start_suggests_standard_labels` still passes
- [x] Full test suite: 93/93 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)